### PR TITLE
Fix: unload anchor when the pf table add fails during activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Without `persist`, pf will remove the table when it becomes empty, causing subse
 
 | Operation | On failure |
 |---|---|
-| Add IP on activate | **Fatal** — HTTP 500 returned, anchor is not activated |
+| Add IP on activate | **Fatal** — HTTP 500 returned, the anchor loaded in step 1 is unloaded again |
 | Remove IP on deactivate | **Warn only** — logged, anchor is still flushed |
 | Remove IP on shutdown / deactivate-all | **Warn only** — logged, all anchors are still flushed |
 | Table existence check on startup | **Fatal** — server refuses to start |

--- a/internal/api/calls.go
+++ b/internal/api/calls.go
@@ -32,6 +32,14 @@ func (h *Handler) CallExecActivateAnchor(c echo.Context, r *authpf.AuthPFAnchor)
 	h.logger.Trace().Str("user", c.Get("username").(string)).Msg(msg)
 
 	if result.ExitCode != 0 {
+		// Roll back the anchor from step 1: it is loaded in pf but not yet
+		// in the session DB, so no cleanup path would ever find it. The IP
+		// was never added to the table, so there is nothing to remove there.
+		if err := h.exec.UnloadAnchor(r); err != nil {
+			h.logger.Error().Err(err).Str("user", r.Username).Msgf(
+				"rollback failed, anchor is still loaded and untracked, remove it with: pfctl -a %s/%s(%d) -F all",
+				h.config.AuthPF.AnchorName, r.Username, r.UserID)
+		}
 		return &errors.APIError{
 			HttpStatusCode: http.StatusInternalServerError,
 			StatusCode:     result.ExitCode,

--- a/internal/api/calls_rollback_test.go
+++ b/internal/api/calls_rollback_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog"
+	"github.com/scd-systems/authpf-api/internal/authpf"
+	"github.com/scd-systems/authpf-api/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// A failed pf table add must unload the anchor that step 1 loaded. The stub
+// pfctl succeeds for every command except table ops (-t), reproducing the
+// half-activated state, and records every invocation for assertions.
+func TestCallExecActivateAnchor_RollsBackAnchorOnTableAddFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	argLog := filepath.Join(tmpDir, "args.log")
+	stub := filepath.Join(tmpDir, "pfctl-stub")
+	script := "#!/bin/sh\n" +
+		"echo \"$@\" >> " + argLog + "\n" +
+		"case \" $* \" in *\" -t \"*) exit 1;; esac\n" +
+		"exit 0\n"
+	assert.NoError(t, os.WriteFile(stub, []byte(script), 0755))
+
+	cfg := &config.ConfigFile{
+		Defaults: config.ConfigFileDefaults{PfctlBinary: stub},
+		AuthPF: config.ConfigFileAuthPF{
+			UserRulesRootFolder: tmpDir,
+			UserRulesFile:       "rules",
+			AnchorName:          "authpf",
+			FlushFilter:         []string{"rules", "nat"},
+			PfTable:             "authpf_users",
+		},
+		Rbac: config.ConfigFileRbac{
+			Users: map[string]config.ConfigFileRbacUsers{
+				"testuser": {Role: "user", UserID: 1000},
+			},
+		},
+	}
+
+	db := authpf.New()
+	logger := zerolog.New(os.Stderr)
+	h, err := New(db, &sync.Mutex{}, logger, cfg)
+	assert.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	c := e.NewContext(req, httptest.NewRecorder())
+	c.Set("username", "testuser")
+
+	anchor := &authpf.AuthPFAnchor{Username: "testuser", UserID: 1000, UserIP: "192.0.2.10"}
+	apiErr := h.CallExecActivateAnchor(c, anchor)
+
+	assert.NotNil(t, apiErr, "table add failure must surface as an APIError")
+	assert.Equal(t, http.StatusInternalServerError, apiErr.HttpStatusCode)
+
+	out, err := os.ReadFile(argLog)
+	assert.NoError(t, err)
+	calls := strings.TrimSpace(string(out))
+
+	// Step 1 loaded the anchor, step 2 failed on -t. Without the rollback the
+	// log ends there and the anchor stays loaded with no DB entry to find it.
+	assert.Contains(t, calls, "-f", "step 1 must have loaded the anchor")
+	assert.Contains(t, calls, "-t authpf_users -T add 192.0.2.10", "step 2 must have been attempted")
+	assert.Contains(t, calls, "-a authpf/testuser(1000) -F rules", "anchor must be unloaded after the failure")
+	assert.Contains(t, calls, "-a authpf/testuser(1000) -F nat", "anchor must be unloaded after the failure")
+}

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -251,6 +251,13 @@ func (e *Exec) FlushAnchor(r *authpf.AuthPFAnchor) error {
 		return nil
 	}
 
+	return e.UnloadAnchor(r)
+}
+
+// Unload anchor rules without consulting the session DB. The activation
+// error path needs this: a half-activated anchor is loaded in pf but never
+// reached the DB, so the FlushAnchor guard above would skip it.
+func (e *Exec) UnloadAnchor(r *authpf.AuthPFAnchor) error {
 	multiResult := e.unloadAuthPFAnchor(r)
 	for i, result := range multiResult.Results {
 		msg := fmt.Sprintf("Exec [%d/%d]: '%s %s', ExitCode: %d, Stdout: %s, StdErr: %s",

--- a/internal/exec/unload_test.go
+++ b/internal/exec/unload_test.go
@@ -1,0 +1,101 @@
+package exec
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/scd-systems/authpf-api/internal/authpf"
+	"github.com/stretchr/testify/assert"
+)
+
+// writeRecordingStub creates a fake pfctl that appends its arguments to a
+// log file, so tests can assert which commands were executed.
+func writeRecordingStub(t *testing.T, dir string) (stub string, argLog string) {
+	t.Helper()
+	stub = filepath.Join(dir, "pfctl-stub")
+	argLog = filepath.Join(dir, "args.log")
+	script := "#!/bin/sh\necho \"$@\" >> " + argLog + "\nexit 0\n"
+	if err := os.WriteFile(stub, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return stub, argLog
+}
+
+// UnloadAnchor must execute the flush commands even when the session DB is
+// empty. A failed activation can be exactly that state, and is in the
+// single-session case this test constructs: the anchor is loaded in pf but was
+// never added to the DB. See TestFlushAnchor_GuardIsGlobalNotPerUser for why
+// that is a case rather than the rule.
+func TestUnloadAnchor_RunsWithEmptyDB(t *testing.T) {
+	tmpDir := t.TempDir()
+	stub, argLog := writeRecordingStub(t, tmpDir)
+
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Defaults.PfctlBinary = stub
+	cfg.AuthPF.FlushFilter = []string{"rules", "nat"}
+
+	db := authpf.New() // empty DB, the half-activated state
+	logger := zerolog.New(os.Stderr)
+	e, err := New(logger, cfg, db)
+	assert.NoError(t, err)
+
+	anchor := &authpf.AuthPFAnchor{Username: "testuser", UserID: 1000, UserIP: "192.0.2.10"}
+	assert.NoError(t, e.UnloadAnchor(anchor))
+
+	out, err := os.ReadFile(argLog)
+	assert.NoError(t, err, "pfctl stub must have been executed despite the empty DB")
+	assert.Contains(t, string(out), "-a authpf/testuser(1000) -F rules")
+	assert.Contains(t, string(out), "-a authpf/testuser(1000) -F nat")
+}
+
+// FlushAnchor keeps its existing behavior: with an empty DB it is a no-op.
+func TestFlushAnchor_SkipsWithEmptyDB(t *testing.T) {
+	tmpDir := t.TempDir()
+	stub, argLog := writeRecordingStub(t, tmpDir)
+
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Defaults.PfctlBinary = stub
+
+	db := authpf.New()
+	logger := zerolog.New(os.Stderr)
+	e, err := New(logger, cfg, db)
+	assert.NoError(t, err)
+
+	anchor := &authpf.AuthPFAnchor{Username: "testuser", UserID: 1000, UserIP: "192.0.2.10"}
+	assert.NoError(t, e.FlushAnchor(anchor))
+
+	_, err = os.ReadFile(argLog)
+	assert.True(t, os.IsNotExist(err), "no pfctl call expected with an empty DB")
+}
+
+// The FlushAnchor guard is a global emptiness check, not a per-user lookup, so
+// the naive rollback (calling FlushAnchor from the activation failure path)
+// misbehaves intermittently: it is a silent no-op only when the failing user is
+// the only session. With any other session active it would have worked. That
+// intermittency is why the DB-independent UnloadAnchor exists.
+func TestFlushAnchor_GuardIsGlobalNotPerUser(t *testing.T) {
+	tmpDir := t.TempDir()
+	stub, argLog := writeRecordingStub(t, tmpDir)
+
+	cfg := createTestConfig(t, tmpDir)
+	cfg.Defaults.PfctlBinary = stub
+	cfg.AuthPF.FlushFilter = []string{"rules"}
+
+	// Another user's session is active; the failing user is absent from the DB.
+	db := authpf.New()
+	db.Add(&authpf.AuthPFAnchor{Username: "otheruser", UserID: 1001, UserIP: "192.0.2.20"})
+
+	logger := zerolog.New(os.Stderr)
+	e, err := New(logger, cfg, db)
+	assert.NoError(t, err)
+
+	absent := &authpf.AuthPFAnchor{Username: "testuser", UserID: 1000, UserIP: "192.0.2.10"}
+	assert.NoError(t, e.FlushAnchor(absent))
+
+	out, err := os.ReadFile(argLog)
+	assert.NoError(t, err, "guard passes when any session exists, so pfctl runs")
+	assert.Contains(t, string(out), "-a authpf/testuser(1000) -F rules",
+		"FlushAnchor flushes a user absent from the DB whenever the DB is non-empty")
+}


### PR DESCRIPTION
Activation is two steps: `LoadAuthPFAnchor` (`calls.go:15`) loads the user's anchor, then
`AddIPToPfTable` (`calls.go:29`) adds the IP to the pf table. When step 2 fails, the error
path at `calls.go:34-41` returns HTTP 500 without unloading the anchor from step 1.

The handler does not clean up either. `handler.go:101-104` returns to the client, so
`AddToDB` at `:107` is never reached and the rollback at `:107-120` never runs. The anchor
is loaded in pf and absent from the session DB. Nothing recovers it: the scheduler
(`scheduler.go:41`), deactivate-all (`exec.go:219`) and shutdown (`shutdown.go:32`) all
iterate the DB, which never got the entry. The rules stay loaded past their timeout until a
restart with `onStartup: import`.

`README.md:390` documents this path as "anchor is not activated". The anchor is activated.
The patch corrects the table.

`FlushAnchor` looks like the obvious call for the failure path and is wrong in a way that
is easy to miss. Its guard is `len(*e.db) < 1` (`exec.go:249`), a **global** emptiness
check rather than a per-user lookup, so it silently returns when the failing user is the
only session and flushes correctly when any unrelated session happens to be active. A
rollback whose correctness depends on other users' sessions is worse than none, so the
DB-independent part is split out as `UnloadAnchor`. `FlushAnchor` keeps its existing early
return, and both behaviours are pinned by tests.

Nothing is removed from the pf table here: step 2 is what failed, so the IP was never
added. If the rollback itself fails, the log line carries the `pfctl` command to clean up
by hand, because at that point no tracked state exists to drive a retry.

Only deployments with a `pfTable` configured are affected; without a table
`AddIPToPfTable` returns a fabricated exit code 0 and step 2 cannot fail.

`FlushAnchor`'s global guard remains semantically wrong for a per-user operation. Left
alone to keep this diff minimal, flagged here so the preserved guard is not read as
endorsed.

## Testing

`TestCallExecActivateAnchor_RollsBackAnchorOnTableAddFailure` uses a stub pfctl that
succeeds for every command except table operations, reproducing the half-activated state,
and asserts the anchor is unloaded afterwards. It fails on `main` with "anchor must be
unloaded after the failure".

`TestFlushAnchor_GuardIsGlobalNotPerUser` pins the intermittency described above, and
`TestFlushAnchor_SkipsWithEmptyDB` pins that `FlushAnchor`'s existing behaviour is
unchanged.

`gofmt`, `go vet` and `go test ./...` are clean (8 packages, go1.26.5 linux/amd64).
