### PR TITLE
Fix: warn about unknown config file keys at startup

### DIFF
--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -60,6 +60,12 @@ func (s *Server) Bootstrap() (err error) {
 		return err
 	}
 
+	// Warn about config keys the decoder dropped silently. A misspelled
+	// optional key like pfTable disables its feature with no other signal.
+	for _, key := range s.config.UnknownKeys {
+		s.logger.Warn().Msgf("unknown config key ignored: %s", key)
+	}
+
 	// Validate Config
 	if err := s.validateConfig(); err != nil {
 		return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"strings"
@@ -34,12 +35,52 @@ func (c *ConfigFile) LoadConfig(configFile string) error {
 		return fmt.Errorf("cannot parse config file: %v", err)
 	}
 
+	// The decoder above drops unknown keys silently, so a misspelled key
+	// disables its feature with no error. Collect them here; the caller
+	// logs them once the logger exists.
+	c.UnknownKeys = collectUnknownKeys(yamlFile)
+
 	// Validate Config
 	if err := c.validateRequiredSections(); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// collectUnknownKeys returns warnings for config keys that match no field in
+// ConfigFile. It re-decodes the same bytes with KnownFields(true) and harvests
+// the resulting yaml.TypeError, so the key set is derived from the struct tags
+// themselves and cannot drift from them. Maps with arbitrary keys (role names,
+// usernames, macro names) are accepted by construction.
+//
+// The caller only reaches this after a successful lenient decode, so any
+// remaining messages describe unknown fields rather than type mismatches. The
+// filter keeps that true if the two decoders ever diverge.
+func collectUnknownKeys(yamlFile []byte) []string {
+	var throwaway ConfigFile
+	dec := yaml.NewDecoder(bytes.NewReader(yamlFile))
+	dec.KnownFields(true)
+
+	err := dec.Decode(&throwaway)
+	if err == nil {
+		return nil
+	}
+	typeErr, ok := err.(*yaml.TypeError)
+	if !ok {
+		return nil
+	}
+
+	// The filter is coupled to yaml.v3's wording. If a future version rewords
+	// it, warnings would silently disappear rather than misfire, so the tests
+	// assert on the message text to make a dependency bump break loudly.
+	var unknown []string
+	for _, msg := range typeErr.Errors {
+		if strings.Contains(msg, "not found in type") {
+			unknown = append(unknown, msg)
+		}
+	}
+	return unknown
 }
 
 // validateRequiredSections checks if all required configuration sections are defined

--- a/pkg/config/loadconfig_unknown_test.go
+++ b/pkg/config/loadconfig_unknown_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A config with a misspelled pfTable must surface the typo via UnknownKeys.
+func TestLoadConfig_ReportsMisspelledKey(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "c.yaml")
+	body := `
+defaults:
+  pfctlBinary: /sbin/pfctl
+server:
+  bind: 127.0.0.1
+  port: 8080
+  logfile: /tmp/l
+  elevatorMode: none
+authpf:
+  timeout: 30m
+  userRulesRootFolder: /etc/authpf/users
+  userRulesFile: authpf.rules
+  anchorName: authpf
+  flushFilter: [rules]
+  pftable: authpf_users
+`
+	assert.NoError(t, os.WriteFile(f, []byte(body), 0640))
+	c := New()
+	assert.NoError(t, c.LoadConfig(f))
+	assert.Len(t, c.UnknownKeys, 1)
+	assert.Contains(t, c.UnknownKeys[0], "pftable")
+	assert.Contains(t, c.UnknownKeys[0], "ConfigFileAuthPF")
+	assert.Contains(t, c.UnknownKeys[0], "line ")
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -18,6 +18,10 @@ type ConfigFile struct {
 	Server   ConfigFileServer   `yaml:"server"`
 	AuthPF   ConfigFileAuthPF   `yaml:"authpf"`
 	Rbac     ConfigFileRbac     `yaml:"rbac"`
+
+	// Keys found in the config file that match no known field. Collected at
+	// load time, logged as warnings once the logger exists. Not persisted.
+	UnknownKeys []string `yaml:"-"`
 }
 
 type ConfigFileDefaults struct {

--- a/pkg/config/unknown_keys_test.go
+++ b/pkg/config/unknown_keys_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollectUnknownKeys(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantCount int
+		wantMatch []string
+	}{
+		{
+			name: "clean config reports nothing",
+			yaml: `
+defaults:
+  pfctlBinary: /sbin/pfctl
+authpf:
+  timeout: 30m
+  pfTable: authpf_users
+rbac:
+  roles:
+    admin:
+      permissions: [view_own_rules]
+  users:
+    alice:
+      role: admin
+      macros:
+        server_1_port: "22"
+`,
+			wantCount: 0,
+		},
+		{
+			name:      "misspelled pfTable is reported, not dropped silently",
+			yaml:      "authpf:\n  pftable: authpf_users\n",
+			wantCount: 1,
+			wantMatch: []string{"pftable"},
+		},
+		{
+			name:      "wrong case is a different key to the decoder",
+			yaml:      "authpf:\n  PfTable: authpf_users\n",
+			wantCount: 1,
+			wantMatch: []string{"PfTable"},
+		},
+		{
+			name:      "unknown top-level section",
+			yaml:      "bogusTop:\n  x: 1\n",
+			wantCount: 1,
+			wantMatch: []string{"bogusTop"},
+		},
+		{
+			name:      "typo nested under a user entry",
+			yaml:      "rbac:\n  users:\n    alice:\n      pftable: t\n",
+			wantCount: 1,
+			wantMatch: []string{"pftable"},
+		},
+		{
+			// The whole reason for deriving from struct tags instead of a
+			// hand-written key list: arbitrary map keys are free.
+			name:      "arbitrary role, user and macro names are not unknown",
+			yaml:      "rbac:\n  roles:\n    weird.role-name:\n      permissions: [x]\n  users:\n    some.user-x:\n      macros:\n        anything_goes: v\n",
+			wantCount: 0,
+		},
+		{
+			name:      "several unknowns are all reported",
+			yaml:      "zz: 1\nauthpf:\n  pftable: t\n",
+			wantCount: 2,
+		},
+		{
+			name:      "messages carry a line number",
+			yaml:      "defaults:\n  pfctlBinary: /sbin/pfctl\n  nope: x\n",
+			wantCount: 1,
+			wantMatch: []string{"line 3", "nope"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collectUnknownKeys([]byte(tt.yaml))
+			assert.Len(t, got, tt.wantCount)
+			for _, want := range tt.wantMatch {
+				joined := ""
+				for _, g := range got {
+					joined += g + "\n"
+				}
+				assert.Contains(t, joined, want)
+			}
+		})
+	}
+}
+
+// Every field of ConfigFile must be reachable by its yaml name. This decodes a
+// document exercising every key in authpf-api.conf.sample and asserts nothing
+// is reported unknown, which is what would break if a tag were renamed.
+func TestCollectUnknownKeys_FullSampleShapeIsClean(t *testing.T) {
+	full := `
+defaults:
+  pfctlBinary: /sbin/pfctl
+authpf:
+  timeout: 30m
+  userRulesRootFolder: /etc/authpf/users
+  userRulesFile: authpf.rules
+  anchorName: authpf
+  flushFilter: [nat, rules]
+  onStartup: importflush
+  onShutdown: flushall
+  pfTable: authpf_users
+server:
+  bind: 127.0.0.1
+  port: 8080
+  ssl:
+    certificate: /etc/ssl/c.pem
+    key: /etc/ssl/k.pem
+  jwtSecret: secret
+  jwtTokenTimeout: 8
+  elevatorMode: none
+  logfile: /var/log/authpf-api.log
+rbac:
+  roles:
+    admin:
+      permissions: [view_own_rules]
+  users:
+    authpf-user1:
+      userRulesFile: authpf.rules
+      password: hash
+      role: user
+      userId: 1001
+      userIp: 192.168.0.10
+      pfTable: authpf_users
+      macros:
+        server_1_port: "22"
+`
+	assert.Empty(t, collectUnknownKeys([]byte(full)))
+}


### PR DESCRIPTION
Config loading uses plain `yaml.Unmarshal` (`pkg/config/config.go:32`), which drops unknown
keys silently. Matching is exact and case sensitive, so `pftable`, `PfTable`, `pf_table`
and `pfTables` all parse with `err=nil` and leave the field empty.

For most keys a typo hits the required-field check. For the optional ones it does not, and
`pfTable` is the dangerous case: with an empty table name `AddIPToPfTable`
(`exec.go:321-332`) returns a fabricated `ExitCode: 0` and logs only at Trace. A one
character typo means client IPs are never added to the table, the API returns success, and
the only evidence is a trace line that is off by default.

After the normal lenient decode, the patch re-decodes the same bytes into a throwaway
`ConfigFile` with `KnownFields(true)` and harvests the resulting `yaml.TypeError`. Each
message is logged at Warn during bootstrap. Configs are never rejected.

Deriving the key set from the struct tags this way is the point: there is no second list to
keep in sync, so a new config field is understood the moment it is added, and maps with
arbitrary keys (role names, usernames, macro names) are accepted by construction. Messages
carry line numbers.

Making the primary decode strict was rejected: it would hard-fail every deployed config
carrying a stale or commented-then-uncommented key that parses today, turning an additive
change into a breaking one.

## Testing

`TestCollectUnknownKeys` covers a clean config, each misspelling class of `pfTable`, an
unknown top-level section, a typo nested under a user entry, arbitrary role/user/macro
names being accepted, several unknowns at once, and the line number in the message.

`TestCollectUnknownKeys_FullSampleShapeIsClean` decodes a document exercising every key in
`authpf-api.conf.sample` and asserts nothing is reported, so a renamed struct tag surfaces
as a test failure rather than as spurious warnings for users.

`TestLoadConfig_ReportsMisspelledKey` covers the end-to-end path through `LoadConfig`.

The filter that selects unknown-field messages is coupled to yaml.v3's wording, and a
reword would make warnings disappear rather than misfire. The tests assert on the message
text so that a dependency bump breaks loudly; there is a comment at the filter saying so.

`gofmt`, `go vet` and `go test ./...` are clean (8 packages, go1.26.5 linux/amd64).
