### PR TITLE
Fix: validate macro key names

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -6,8 +6,6 @@ import (
 	"regexp"
 	"strings"
 	"unicode/utf8"
-
-	"github.com/scd-systems/authpf-api/pkg/config"
 )
 
 // Validate ConfigFile Values
@@ -35,8 +33,8 @@ func (s *Server) validateConfig() (err error) {
 			if err = validateAlphanumericASCII(mkey, mvalue); err != nil {
 				return err
 			}
-			if err = validateMacroKey(v, mkey); err != nil {
-				nerr := fmt.Errorf("same twice parameters found for user %s in configuration, %s", k, err)
+			if err = validateMacroKey(mkey); err != nil {
+				nerr := fmt.Errorf("invalid macro for user %s in configuration, %s", k, err)
 				return nerr
 			}
 		}
@@ -87,14 +85,30 @@ func validateIPAddr(value string) error {
 	return nil
 }
 
-func validateMacroKey(user config.ConfigFileRbacUsers, value string) error {
-	if len(value) > 0 {
-		if chk := strings.Compare(value, "user_ip"); chk == 0 && len(user.UserIP) > 0 {
-			return fmt.Errorf("userIp and macro user_ip defined (same)")
-		}
-		if chk := strings.Compare(value, "user_id"); chk == 0 && user.UserID > 0 {
-			return fmt.Errorf("userId and macro user_id defined (same)")
-		}
+// pf.conf(5) documents macro names as starting with a letter, followed by
+// letters, digits and underscores. The lexer is looser than the manual, but
+// validating against the documented contract keeps a config that passes
+// startup from failing at activation time.
+var validMacroKeyRegex = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
+
+// validateMacroKey checks the macro name itself. Only the value was ever
+// checked: validateAlphanumericASCII takes (key, value) and regex-tests the
+// value, using the key solely to label the error.
+//
+// A key that is not a valid pf macro name still reaches pfctl as part of the
+// -D argument, and produces a macro that no rules file can reference. Worse,
+// it changes the shape of the argument the sudoers or doas allowlist matches
+// against, so the config validates at startup and the activation fails later.
+//
+// user_ip and user_id are rejected outright. The app always passes both
+// itself, before the user macros, and pfctl keeps the first definition of a
+// command-line macro, so a user macro with either name is silently discarded.
+func validateMacroKey(value string) error {
+	if !validMacroKeyRegex.MatchString(value) {
+		return fmt.Errorf("invalid macro key %q, only [A-Za-z][A-Za-z0-9_]* allowed", value)
+	}
+	if value == "user_ip" || value == "user_id" {
+		return fmt.Errorf("macro key %q collides with the built-in pfctl macro of the same name", value)
 	}
 	return nil
 }

--- a/internal/server/config_macrokey_behavior_test.go
+++ b/internal/server/config_macrokey_behavior_test.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/scd-systems/authpf-api/pkg/config"
+)
+
+// Goes through validateConfig rather than the validator directly, so the same
+// test compiles before and after the fix and demonstrates the behavior change.
+func TestValidateConfig_RejectsHostileMacroKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{name: "plain key accepted", key: "server_1_port", wantErr: false},
+		{name: "argv injection shape rejected", key: "x=1 -F all", wantErr: true},
+		{name: "hyphen rejected", key: "my-macro", wantErr: true},
+		{name: "shell metacharacter rejected", key: "x;rm", wantErr: true},
+		{name: "user_ip rejected even when userIp is unset", key: "user_ip", wantErr: true},
+		{name: "user_id rejected even when userId is unset", key: "user_id", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{
+				logger: zerolog.Nop(),
+				config: &config.ConfigFile{
+					Rbac: config.ConfigFileRbac{
+						Users: map[string]config.ConfigFileRbacUsers{
+							"alice": {
+								Role:   "user",
+								Macros: map[string]string{tt.key: "value"},
+							},
+						},
+					},
+				},
+			}
+			err := s.validateConfig()
+			if tt.wantErr {
+				assert.Error(t, err, "macro key %q must be rejected", tt.key)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -11,108 +11,46 @@ import (
 func TestValidateMacroKey(t *testing.T) {
 	tests := []struct {
 		name    string
-		user    config.ConfigFileRbacUsers
 		key     string
 		wantErr bool
 		errMsg  string
 	}{
+		{name: "plain key", key: "my_macro", wantErr: false},
+		{name: "uppercase key", key: "SERVER_1_PORT", wantErr: false},
+		// errMsg carries the full charset here so the message and the regex
+		// cannot drift apart silently again.
 		{
-			name: "no conflict: key is user_ip but UserIP is empty",
-			user: config.ConfigFileRbacUsers{
-				UserIP: "",
-				Macros: map[string]string{"user_ip": "10.0.0.1"},
-			},
-			key:     "user_ip",
-			wantErr: false,
+			name:    "leading underscore rejected, pf.conf documents letter-first",
+			key:     "_internal",
+			wantErr: true,
+			errMsg:  `invalid macro key "_internal", only [A-Za-z][A-Za-z0-9_]* allowed`,
 		},
+		{name: "reserved-looking but distinct key", key: "user_ip2", wantErr: false},
+		{name: "mixed case is not the reserved name", key: "User_Ip", wantErr: false},
 		{
-			name: "no conflict: UserIP set but key is not user_ip",
-			user: config.ConfigFileRbacUsers{
-				UserIP: "192.168.1.1",
-				Macros: map[string]string{"my_macro": "value"},
-			},
-			key:     "my_macro",
-			wantErr: false,
-		},
-		{
-			name: "conflict: UserIP set and key is user_ip",
-			user: config.ConfigFileRbacUsers{
-				UserIP: "192.168.1.1",
-				Macros: map[string]string{"user_ip": "10.0.0.1"},
-			},
+			name:    "user_ip always rejected, the app passes -D user_ip itself",
 			key:     "user_ip",
 			wantErr: true,
-			errMsg:  "userIp and macro user_ip defined (same)",
+			errMsg:  "collides with the built-in pfctl macro",
 		},
 		{
-			name: "no conflict: both UserIP and key are empty",
-			user: config.ConfigFileRbacUsers{
-				UserIP: "",
-				Macros: map[string]string{},
-			},
-			key:     "",
-			wantErr: false,
-		},
-		{
-			name: "no conflict: key is empty, UserIP is set",
-			user: config.ConfigFileRbacUsers{
-				UserIP: "10.0.0.1",
-				Macros: map[string]string{},
-			},
-			key:     "",
-			wantErr: false,
-		},
-		{
-			name: "no conflict: key USER_IP is case-sensitive, UserIP is set",
-			user: config.ConfigFileRbacUsers{
-				UserIP: "10.0.0.1",
-				Macros: map[string]string{"USER_IP": "value"},
-			},
-			key:     "USER_IP",
-			wantErr: false,
-		},
-		{
-			name: "no conflict: key User_Ip mixed case, UserIP is set",
-			user: config.ConfigFileRbacUsers{
-				UserIP: "10.0.0.1",
-				Macros: map[string]string{"User_Ip": "value"},
-			},
-			key:     "User_Ip",
-			wantErr: false,
-		},
-		{
-			name: "conflict: UserID set and key is user_id",
-			user: config.ConfigFileRbacUsers{
-				UserID: 1000,
-				Macros: map[string]string{"user_id": "1000"},
-			},
+			name:    "user_id always rejected, the app passes -D user_id itself",
 			key:     "user_id",
 			wantErr: true,
-			errMsg:  "userId and macro user_id defined (same)",
+			errMsg:  "collides with the built-in pfctl macro",
 		},
-		{
-			name: "no conflict: key user_id but UserID is zero",
-			user: config.ConfigFileRbacUsers{
-				UserID: 0,
-				Macros: map[string]string{"user_id": "0"},
-			},
-			key:     "user_id",
-			wantErr: false,
-		},
-		{
-			name: "no conflict: key User_Id mixed case, UserID is set (case-sensitive)",
-			user: config.ConfigFileRbacUsers{
-				UserID: 1000,
-				Macros: map[string]string{"User_Id": "1000"},
-			},
-			key:     "User_Id",
-			wantErr: false,
-		},
+		{name: "empty key", key: "", wantErr: true, errMsg: "invalid macro key"},
+		{name: "leading digit", key: "1port", wantErr: true, errMsg: "invalid macro key"},
+		{name: "hyphen", key: "my-macro", wantErr: true, errMsg: "invalid macro key"},
+		{name: "dot", key: "my.macro", wantErr: true, errMsg: "invalid macro key"},
+		{name: "space", key: "my macro", wantErr: true, errMsg: "invalid macro key"},
+		{name: "shell metacharacters", key: "x;rm", wantErr: true, errMsg: "invalid macro key"},
+		{name: "argv injection shape", key: "x=1 -F all", wantErr: true, errMsg: "invalid macro key"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateMacroKey(tt.user, tt.key)
+			err := validateMacroKey(tt.key)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMsg)


### PR DESCRIPTION
Macro keys are never validated. `internal/server/config.go:35` calls
`validateAlphanumericASCII(mkey, mvalue)`, but the signature is `(key, value string)` and
only `value` is regex-tested; the key is used solely to label the error. It reads like key
validation and is not.

**This is not argv injection.** `exec.Command` passes each `-D key=value` pair as a single
argv element to execve, with no shell anywhere in the path, in every elevator mode. What a
malformed key actually does is produce a macro no rules file can reference, and change the
shape of the argument the documented sudoers and doas allowlists match against, so a config
that passes startup validation fails later at activation. The config author is
root-equivalent, so this is config hygiene and defence in depth for the elevator layer, not
a privilege boundary.

The reserved names were only conditionally rejected: `validateMacroKey`
(`config.go:90-100`) refused `user_ip` only when `userIp` was set, and `user_id` only when
`userId` was set. The app always passes both itself (`exec.go:172-181`), ahead of the user
macros. Command-line macros are registered with `persist=1` and `symset()` returns early
when a persistent symbol of that name already exists, so the **first** definition wins and
the user's macro is silently discarded. Rejecting it unconditionally is honest about that.

The gate is `^[A-Za-z][A-Za-z0-9_]*$`, matching what pf.conf(5) documents for macro names.
The lexer is looser (it accepts a leading underscore), but validating the documented
contract rather than observed behaviour is free here.

Reserved pf keywords as macro names (`pass`, `in`, `table`) are not covered; a denylist is
a larger change than this fix warrants, and is noted rather than silently skipped.

## Breaking change

This can reject a config that is accepted today: a hyphenated macro name, a leading
underscore, or a macro named `user_ip` with no `userIp` set. Migration is to rename the
macro. Happy to add a CHANGELOG entry, a minor version bump, or both, whichever you prefer.

## Testing

`TestValidateMacroKey` asserted the old conditional contract and is rewritten. The
leading-underscore case asserts the full error message including the charset, so the
message and the regex cannot drift apart silently.

`TestValidateConfig_RejectsHostileMacroKeys` goes through `validateConfig` rather than the
validator directly, so it compiles against both the old and the new code and demonstrates
the behaviour change: on `main` five of its six subtests fail.

`gofmt`, `go vet` and `go test ./...` are clean (8 packages, go1.26.5 linux/amd64).
